### PR TITLE
Volumes habilitados no docker-compose-cginf.yml

### DIFF
--- a/docker-compose-cginf.yml
+++ b/docker-compose-cginf.yml
@@ -56,10 +56,10 @@
         AIRFLOW__WEBSERVER__SECRET_KEY: '42'
         AIRFLOW__WEBSERVER__WORKERS: 1
       volumes:
-        # - ../airflow-dags/dags:/opt/airflow/dags
-        # - ../FastETL:/opt/airflow/plugins/FastETL
-        # - ../airflow_commons:/opt/airflow/plugins/airflow_commons
-        # - ../airflow-dags/great_expectations:/opt/airflow/great_expectations
+        - ../airflow-dags/dags:/opt/airflow/dags
+        - ../FastETL:/opt/airflow/plugins/FastETL
+        - ../airflow_commons:/opt/airflow/plugins/airflow_commons
+        - ../airflow-dags/great_expectations:/opt/airflow/great_expectations
         - /var/run/docker.sock:/var/run/docker.sock
         - /usr/bin/docker:/bin/docker:ro
 

--- a/docker-compose-cginf.yml
+++ b/docker-compose-cginf.yml
@@ -61,7 +61,8 @@
         - ../airflow_commons:/opt/airflow/plugins/airflow_commons
         - ../airflow-dags/great_expectations:/opt/airflow/great_expectations
         - /var/run/docker.sock:/var/run/docker.sock
-        - /usr/bin/docker:/bin/docker:ro
+        # - /usr/bin/docker:/bin/docker:ro
+        # - /snap/bin/docker:/bin/docker:ro
 
       user: "${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-50000}"
       depends_on:


### PR DESCRIPTION
Descomentar os volumes. Se o usuário seguir o passo-a-passo de clonagem, naturalmente os diretórios ficarão irmãos na estrutura. Já existe na documentação a informação de que as pastas devem ficar dessa forma.