### PR TITLE
Explicitar requisito de docker-compose no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ https://airflow.apache.org/docs/apache-airflow/stable/start/docker.html.
 
 1. Instalar Docker CE [aqui!](https://docs.docker.com/get-docker/)
 
-   Obs.: no Ubuntu 20.04, recomenda-se instalar o docker a partir do
+   Obs.: É necessário que o `docker-compose` tenha versão mínima 1.29.
+   No Ubuntu 20.04, recomenda-se instalar o docker a partir do
    gerenciador de pacotes *snap*:
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -22,33 +22,33 @@ https://airflow.apache.org/docs/apache-airflow/stable/start/docker.html.
    [airflow2-docker](https://github.com/economiagovbr/airflow2-docker)
    na máquina
 
-```bash
-git clone git@github.com:economiagovbr/airflow2-docker.git
-cd airflow2-docker
-```
+   ```bash
+   git clone git@github.com:economiagovbr/airflow2-docker.git
+   cd airflow2-docker
+   ```
 
 3. No Linux, os volumes montados no contêiner usam as permissões de
    usuário / grupo do sistema de arquivos Linux nativo, portanto, você
    deve certificar-se de que o contêiner e o computador host têm
    permissões de arquivo correspondentes.
 
-```bash
-echo -e "AIRFLOW_UID=$(id -u)\nAIRFLOW_GID=0" > .env
-```
+   ```bash
+   echo -e "AIRFLOW_UID=$(id -u)\nAIRFLOW_GID=0" > .env
+   ```
 
 4. Dentro da pasta clonada (na raiz do arquivo Dockerfile), executar o
    comando para gerar a estrutura do banco Postgres local
 
-```bash
-docker-compose -f docker-compose-cginf.yml up airflow-init
-```
+   ```bash
+   docker-compose -f docker-compose-cginf.yml up airflow-init
+   ```
 
-> Se o docker build retornar a mensagem `error checking context:
-> 'can't stat '/home/<user-linux>/.../mnt/pgdata''.`, então executar:
+   > Se o docker build retornar a mensagem `error checking context:
+   > 'can't stat '/home/<user-linux>/.../mnt/pgdata''.`, então executar:
 
-```bash
-sudo chown -R <user-linux> mnt/pgdata
-```
+   ```bash
+   sudo chown -R <user-linux> mnt/pgdata
+   ```
 
 Após a conclusão da inicialização, você deverá ver uma mensagem
 como a seguir:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ https://airflow.apache.org/docs/apache-airflow/stable/start/docker.html.
 
 1. Instalar Docker CE [aqui!](https://docs.docker.com/get-docker/)
 
+   Obs.: no Ubuntu 20.04, recomenda-se instalar o docker a partir do
+   gerenciador de pacotes *snap*:
+
+   ```bash
+   snap install docker
+   ```
+
 2. Clonar o repositório
    [airflow2-docker](https://github.com/economiagovbr/airflow2-docker)
    na máquina


### PR DESCRIPTION
Frequentemente quem usa este ambiente se depara com um erro no passo 4, uma vez que diversas formas comuns de se instalar o Docker deixam com um `docker-compose` antigo e incompatível com este projeto.

## Solução

* Documentar explicitamente que é necessário ter o `docker-compose` no mínimo na versão 1.29
* Sugerir a forma de instalação pelo snap, que é um gerenciador de pacotes e já traz uma versão compatível