### PR TITLE
Corrige mapeamento de volume para o DockerOperator

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,18 @@ https://airflow.apache.org/docs/apache-airflow/stable/start/docker.html.
    echo -e "AIRFLOW_UID=$(id -u)\nAIRFLOW_GID=0" > .env
    ```
 
-4. Dentro da pasta clonada (na raiz do arquivo Dockerfile), executar o
+4. Para que funcionem as dags que usam DockerOperator, é necessário
+   configurar um volume no arquivo do yml docker-compose (ex.:
+   `docker-compose-cginf.yml`). Digite
+
+   ```bash
+   which docker
+   ```
+
+   para ver o caminho correto para o Docker e descomente a linha
+   correspondente a esse caminho na seção "volumes".
+
+5. Dentro da pasta clonada (na raiz do arquivo Dockerfile), executar o
    comando para gerar a estrutura do banco Postgres local
 
    ```bash

--- a/docker-compose-cginf.yml
+++ b/docker-compose-cginf.yml
@@ -61,6 +61,8 @@
         - ../airflow_commons:/opt/airflow/plugins/airflow_commons
         - ../airflow-dags/great_expectations:/opt/airflow/great_expectations
         - /var/run/docker.sock:/var/run/docker.sock
+        # Caso precise usar DockerOperator no ambiente, digite "which docker" e
+        # descomente abaixo a linha correspondente.
         # - /usr/bin/docker:/bin/docker:ro
         # - /snap/bin/docker:/bin/docker:ro
 

--- a/docker-compose-delog.yml
+++ b/docker-compose-delog.yml
@@ -61,7 +61,10 @@
         - ../airflow_commons:/opt/airflow/plugins/airflow_commons
         - ../airflow-dags/great_expectations:/opt/airflow/great_expectations
         - /var/run/docker.sock:/var/run/docker.sock
-        - /usr/bin/docker:/bin/docker:ro
+        # Caso precise usar DockerOperator no ambiente, digite "which docker" e
+        # descomente abaixo a linha correspondente.
+        # - /usr/bin/docker:/bin/docker:ro
+        # - /snap/bin/docker:/bin/docker:ro
 
       user: "${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-50000}"
       depends_on:

--- a/docker-compose-detru.yml
+++ b/docker-compose-detru.yml
@@ -61,7 +61,10 @@
         - ../airflow_commons:/opt/airflow/plugins/airflow_commons
         - ../airflow-dags/great_expectations:/opt/airflow/great_expectations
         - /var/run/docker.sock:/var/run/docker.sock
-        - /usr/bin/docker:/bin/docker:ro
+        # Caso precise usar DockerOperator no ambiente, digite "which docker" e
+        # descomente abaixo a linha correspondente.
+        # - /usr/bin/docker:/bin/docker:ro
+        # - /snap/bin/docker:/bin/docker:ro
 
       user: "${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-50000}"
       depends_on:


### PR DESCRIPTION
Acrescenta um passo adicional para configurar o DockerOperator no ambiente, dependendo se o usuário instalou o Docker pelo apt ou snap. Basta descomentar a linha correspondente no arquivo yaml do docker compose.