### PR TITLE
Use build matrix to upgrade services in parallel

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,14 +42,15 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_LABEL }}
           
-  release:
+  upgrade:
   
     needs: build-and-push-image
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        service: [worker, scheduler, flower, webserver, worker-ftp-route, worker-dockeroperator]
+        service: [airflow-worker, airflow-scheduler, flower, airflow-webserver,
+          airflow-worker-ftp-route, airflow-worker-dockeroperator]
     
     steps:
       - name: upgrade ${{ matrix.service }}
@@ -60,5 +61,5 @@ jobs:
           rancher_key: ${{ secrets.RANCHER_KEY }}
           project_id: 1a656207
           stack_name: airflow2-hmg
-          service_name: airflow-${{ matrix.service }}
+          service_name: ${{ matrix.service }}
           docker_image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_LABEL }}    

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Build, publish and release a Docker image
 
 on:
   push:
-#     branches: [ main ]
+    branches: [ github_actions_build_matrix ]
     tags:
       - '*'
     
@@ -46,9 +46,13 @@ jobs:
   
     needs: build-and-push-image
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        service: [worker, scheduler, flower, webserver, worker-ftp-route, worker-dockeroperator]
     
     steps:
-      - name: upgrade worker
+      - name: upgrade ${{ matrix.service }}
         uses: sekassel-research/actions-rancher-update@1.1.4
         with:
           rancher_url: https://rancher.dev.economia.gov.br
@@ -56,60 +60,5 @@ jobs:
           rancher_key: ${{ secrets.RANCHER_KEY }}
           project_id: 1a656207
           stack_name: airflow2-hmg
-          service_name: airflow-worker
+          service_name: airflow-${{ matrix.service }}
           docker_image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_LABEL }}    
-          
-      - name: upgrade scheduler
-        uses: sekassel-research/actions-rancher-update@1.1.4
-        with:
-          rancher_url: https://rancher.dev.economia.gov.br
-          rancher_access: ${{ secrets.RANCHER_ACCESS }}
-          rancher_key: ${{ secrets.RANCHER_KEY }}
-          project_id: 1a656207
-          stack_name: airflow2-hmg
-          service_name: airflow-scheduler
-          docker_image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_LABEL }}            
-    
-      - name: upgrade flower
-        uses: sekassel-research/actions-rancher-update@1.1.4
-        with:
-          rancher_url: https://rancher.dev.economia.gov.br
-          rancher_access: ${{ secrets.RANCHER_ACCESS }}
-          rancher_key: ${{ secrets.RANCHER_KEY }}
-          project_id: 1a656207
-          stack_name: airflow2-hmg
-          service_name: flower
-          docker_image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_LABEL }}
-
-      - name: upgrade webserver
-        uses: sekassel-research/actions-rancher-update@1.1.4
-        with:
-          rancher_url: https://rancher.dev.economia.gov.br
-          rancher_access: ${{ secrets.RANCHER_ACCESS }}
-          rancher_key: ${{ secrets.RANCHER_KEY }}
-          project_id: 1a656207
-          stack_name: airflow2-hmg
-          service_name: airflow-webserver
-          docker_image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_LABEL }}
-          
-      - name: upgrade worker-85
-        uses: sekassel-research/actions-rancher-update@1.1.4
-        with:
-          rancher_url: https://rancher.dev.economia.gov.br
-          rancher_access: ${{ secrets.RANCHER_ACCESS }}
-          rancher_key: ${{ secrets.RANCHER_KEY }}
-          project_id: 1a656207
-          stack_name: airflow2-hmg
-          service_name: airflow-worker-85
-          docker_image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_LABEL }}    
-          
-      - name: upgrade worker-bigmemory
-        uses: sekassel-research/actions-rancher-update@1.1.4
-        with:
-          rancher_url: https://rancher.dev.economia.gov.br
-          rancher_access: ${{ secrets.RANCHER_ACCESS }}
-          rancher_key: ${{ secrets.RANCHER_KEY }}
-          project_id: 1a656207
-          stack_name: airflow2-hmg
-          service_name: airflow-worker-bigmemory
-          docker_image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_LABEL }}              

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Build, publish and release a Docker image
 
 on:
   push:
-    branches: [ github_actions_build_matrix ]
+    # branches: [ github_actions_build_matrix ]
     tags:
       - '*'
     


### PR DESCRIPTION
In Github Actions you can define a [build matrix](https://docs.github.com/en/actions/using-jobs/using-a-build-matrix-for-your-jobs), which is usually for CI with different versions of supported platforms, etc., but we try it to upgrade services in Rancher in parallel.