### PR TITLE
Change Github Actions script to new forked version

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Build, publish and release a Docker image
 
 on:
   push:
-    # branches: [ github_actions_build_matrix ]
+    branches: [ github_actions_build_matrix ]
     tags:
       - '*'
     
@@ -54,7 +54,7 @@ jobs:
     
     steps:
       - name: upgrade ${{ matrix.service }}
-        uses: sekassel-research/actions-rancher-update@1.1.4
+        uses: economiagovbr/actions-rancher-update@1.1.5
         with:
           rancher_url: https://rancher.dev.economia.gov.br
           rancher_access: ${{ secrets.RANCHER_ACCESS }}
@@ -62,4 +62,6 @@ jobs:
           project_id: 1a656207
           stack_name: airflow2-hmg
           service_name: ${{ matrix.service }}
-          docker_image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_LABEL }}    
+          docker_image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_LABEL }}
+          retry_count: 20
+          retry_delay: 15

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Build, publish and release a Docker image
 
 on:
   push:
-    branches: [ github_actions_build_matrix ]
+    # branches: [ github_actions_build_matrix ]
     tags:
       - '*'
     

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,7 +42,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_LABEL }}
           
-  upgrade:
+  rancher-upgrade:
   
     needs: build-and-push-image
     runs-on: ubuntu-latest


### PR DESCRIPTION
We have forked the [sekassel-research/actions-rancher-update](https://github.com/sekassel-research/actions-rancher-update) Github Actions to add retry count and delay options.

We also use these options in order for the deploy process to properly wait for the Rancher upgrade before triggering the "finish upgrade". With that, the whole process is automated.

Fixes #15.