### PR TITLE
Add shell scripts as shortcuts to python in container

### DIFF
--- a/docker_airflow_ipython.sh
+++ b/docker_airflow_ipython.sh
@@ -1,0 +1,1 @@
+docker exec -it localdev_airflow-webserver_1 /home/airflow/.local/bin/ipython $*

--- a/docker_airflow_python.sh
+++ b/docker_airflow_python.sh
@@ -1,0 +1,1 @@
+docker exec -it localdev_airflow-webserver_1 /usr/local/bin/python3 $*


### PR DESCRIPTION
Adds:
* one script as a shortcut to python
* one script as a shortcut to ipython

for executing python inside the webserver container, for e.g. debugging.