### PR TITLE
Remove selenium container (not used)

### DIFF
--- a/docker-compose-cginf.yml
+++ b/docker-compose-cginf.yml
@@ -103,8 +103,3 @@
         <<: *airflow-common
         command: scheduler
         restart: always
-
-      selenium:
-        image: ghcr.io/economiagovbr/selenium:ro-dou
-        volumes:
-          - /dev/shm:/dev/shm


### PR DESCRIPTION
Remove unused container selenium from docker-compose file.

Not necessary anymore since Ro-DOU changed the request method.